### PR TITLE
fix: vagrant version on ubuntu jammy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v3
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -62,4 +62,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          # platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ENV TERM xterm-256color
 RUN apt-get update -y && \
     apt-get install -y \
     qemu-kvm \
-    vagrant \
     build-essential \
     libvirt-daemon-system \
     libvirt-dev \
@@ -19,8 +18,14 @@ RUN apt-get update -y && \
     apt-get autoremove -y && \
     apt-get clean
 
-RUN vagrant plugin install vagrant-libvirt && \
-    vagrant box add --provider libvirt peru/windows-server-2022-standard-x64-eval && \
+# Installation of vagrant
+RUN wget https://releases.hashicorp.com/vagrant/2.4.0/vagrant_2.4.0-1_amd64.deb && \
+    apt install ./vagrant_2.4.0-1_amd64.deb && \
+    rm -rf ./vagrant_2.4.0-1_amd64.deb
+# Installtion of vagrant plugins
+RUN vagrant plugin install vagrant-libvirt
+# Installtion of vagrant box
+RUN vagrant box add --provider libvirt peru/windows-server-2022-standard-x64-eval && \
     vagrant init peru/windows-server-2022-standard-x64-eval
 
 ENV PRIVILEGED=true


### PR DESCRIPTION
# Current Behaviour
- The run of vagrant VM failed due to vagrant package included on Ubuntu jammy repository
- The version of vagrant version is 2.2.19+dfsg-1ubuntu1
- We build images for arm64 arch Linux systems
# Expected behaviour
- We update the version of vagrant to vagrant_2.4.0-1_amd64.
- We remove the build of arm64 due to luck of vagrant Linux/arm64 support.

# Linked Issues
https://github.com/vaggeliskls/windows-in-docker-container/issues/3