### PR TITLE
chore: clean up Dockerfile and startup.sh

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 # Vagrant image settings
-MEMORY=8000 # 8GB
+MEMORY=8000     # MiB (~8 GB)
 CPU=4
-DISK_SIZE=100
+DISK_SIZE=100   # GiB

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,41 @@
 # syntax=docker/dockerfile:1
 FROM ubuntu:24.04
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV TERM xterm-256color
+LABEL org.opencontainers.image.source="https://github.com/vaggeliskls/windows-in-docker-container" \
+      org.opencontainers.image.description="Windows VM (Vagrant + libvirt) inside a Linux container"
 
-RUN apt-get update -y && \
-    apt-get install -y \
-    qemu-kvm \
-    build-essential \
-    libvirt-daemon-system \
-    libvirt-clients \
-    libvirt-dev \
-    ebtables \
-    openssh-server \
-    curl \
-    net-tools \
-    gettext-base \
-    kmod \
-    rsync \
-    samba \
-    jq && \
-    apt-get autoremove -y && \
-    apt-get clean
+ENV DEBIAN_FRONTEND=noninteractive \
+    TERM=xterm-256color
 
-# Installation of vagrant
 ARG VAGRANT_VERSION=2.4.3
 ARG VAGRANT_BOX=peru/windows-server-2022-standard-x64-eval
-RUN wget https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}-1_amd64.deb && \
-    apt install ./vagrant_${VAGRANT_VERSION}-1_amd64.deb && \
-    rm -rf ./vagrant_${VAGRANT_VERSION}-1_amd64.deb
-# Installtion of vagrant plugins
-RUN vagrant plugin install vagrant-libvirt
-# Installtion of vagrant box
-RUN vagrant box add --provider libvirt ${VAGRANT_BOX} && \
-    vagrant init ${VAGRANT_BOX}
 
-ENV PRIVILEGED=true
-ENV INTERACTIVE=true
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        wget \
+        curl \
+        jq \
+        kmod \
+        gettext-base \
+        openssh-server \
+        qemu-kvm \
+        libvirt-daemon-system \
+        libvirt-clients \
+        libvirt-dev \
+        ebtables \
+        cpu-checker \
+        build-essential && \
+    wget -q "https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}-1_amd64.deb" && \
+    apt-get install -y --no-install-recommends "./vagrant_${VAGRANT_VERSION}-1_amd64.deb" && \
+    rm -f "./vagrant_${VAGRANT_VERSION}-1_amd64.deb" && \
+    vagrant plugin install vagrant-libvirt && \
+    vagrant box add --provider libvirt "${VAGRANT_BOX}" && \
+    vagrant init "${VAGRANT_BOX}" && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 ENV VAGRANT_BOX=$VAGRANT_BOX
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -13,20 +13,22 @@ Ensure your system meets the following requirements:
 
 - **Virtualization Enabled:**
   - Check with:
-    - `grep -E -o 'vmx|svm' /proc/cpuinfo`
+    - `lscpu | grep -i Virtualization`
   - Output indicates:
-    - `vmx` → Intel VT-x is supported & enabled.
-    - `svm` → AMD-V is supported & enabled.
+    - `VT-x` → Intel virtualization is supported & enabled.
+    - `AMD-V` → AMD virtualization is supported & enabled.
   - If virtualization is not enabled, enable it in the BIOS/UEFI settings.
+
+- **`cgroup: host`** in the compose file is required: libvirt and the daemons it spawns need full cgroup access, otherwise the container fails to start on cgroup v2 hosts.
 
 ## 🚀 Deployment Guide
 
 1. Create/Update the environmental file `.env`
 ```
 # Vagrant image settings
-MEMORY=8000 # 8GB
+MEMORY=8000     # MiB (~8 GB)
 CPU=4
-DISK_SIZE=100
+DISK_SIZE=100   # GiB
 ```
 2. Create `docker-compose.yml`
 ```yaml
@@ -44,7 +46,7 @@ services:
       - 3389:3389
       - 2222:2222
 ```
-4. Create `docker-compose.override.yml` when you want your VM to be persistent
+3. Create `docker-compose.override.yml` when you want your VM to be persistent
 ```yaml
 services:
   win10:
@@ -65,7 +67,9 @@ volumes:
     name: libvirt_config
 ```
 
-5. Run: `docker compose up -d`
+4. Run: `docker compose up -d`
+
+> **First boot takes several minutes** — the Vagrant box is already baked into the image, but the VM still has to boot and run the provisioning script (Chocolatey install, disk resize, registry tweaks). Follow progress with `docker compose logs -f`.
 
 > When you want to destroy everything `docker compose down -v`
 
@@ -97,9 +101,23 @@ Default users based on the Vagrant image are:
 1. Administrator
     - Username: Administrator
     - Password: vagrant
-1. User
+2. User
     - Username: vagrant
     - Password: vagrant
+
+## ⚠️ Limitations
+
+- **Linux host only** — depends on `/dev/kvm` and libvirt; macOS and Windows hosts are not supported.
+- **Eval license** — the underlying box ships an evaluation copy of Windows Server 2022. Activation expires per Microsoft's eval terms.
+- **No synced folders** — `rsync`, `smb`, and `nfs` are all unwired in the [Vagrantfile](Vagrantfile) (rsync needs a Windows-side install before provisioning runs; SMB synced folders aren't supported with a Linux host; in-container NFS hits `no support in current kernel`).
+- **Performance** — without nested KVM available to Docker (e.g. on a cloud VM that doesn't expose KVM), the guest falls back to plain QEMU and is several times slower.
+
+## 🔧 Troubleshooting
+
+- **`KVM acceleration is not available`** in logs → the host isn't exposing `/dev/kvm`. Check virtualization is enabled in BIOS, the `kvm` module is loaded (`lsmod | grep kvm`), and `/dev/kvm` exists on the host. The startup script falls back to QEMU automatically; expect a large slowdown.
+- **Port 3389 / 2222 already in use** → another RDP/SSH service is bound on the host. Stop it, or change the host-side port mapping in `docker-compose.yml`.
+- **Container exits immediately** → almost always a cgroup or privilege problem. Confirm `privileged: true` and `cgroup: host` are set, then check `docker compose logs win10`.
+- **`vagrant up` hangs at "Waiting for domain to get an IP address"** → libvirt's default NAT network isn't running. Restart the container, or run `virsh net-start default` from inside it.
 
 ## 📚 Further Reading and Resources
 

--- a/startup.sh
+++ b/startup.sh
@@ -1,20 +1,24 @@
 #!/bin/bash
 set -eou pipefail
-pwd
-# Start services
+
+# Allow libvirt access to KVM device when present
 [ -e /dev/kvm ] && chown root:kvm /dev/kvm
-# dbus-daemon --system --fork
-libvirtd --daemon
+
+# Start libvirt services. Direct daemon logs to a file we can tail at the end.
+mkdir -p /var/log/libvirt
+LIBVIRT_LOG_OUTPUTS="1:file:/var/log/libvirt/libvirtd.log" libvirtd --daemon
 virtlogd --daemon
+
+# Fall back to qemu if KVM acceleration is unavailable
 if kvm-ok 2>&1 | grep -q "KVM acceleration can NOT be used"; then
     export LIBVIRT_DRIVER="qemu"
-    echo "--> KVM acceleration can NOT be used"
+    echo "--> KVM acceleration is not available, falling back to qemu"
 fi
-# smbd --daemon
-# Start vagrant box
-# Debug: --debug
+
+# Boot the Vagrant VM
 vagrant up --provider=libvirt
-# Display running boxes
+
+# Show running domains, then keep the container alive by tailing libvirt logs
 virsh list --all
-# Keep container running
-exec tail -f /dev/null
+touch /var/log/libvirt/libvirtd.log
+exec tail -F /var/log/libvirt/libvirtd.log

--- a/startup.sh
+++ b/startup.sh
@@ -9,6 +9,12 @@ mkdir -p /var/log/libvirt
 LIBVIRT_LOG_OUTPUTS="1:file:/var/log/libvirt/libvirtd.log" libvirtd --daemon
 virtlogd --daemon
 
+# Wait for libvirtd to accept connections before driving it
+for _ in $(seq 1 30); do
+    virsh -c qemu:///system version >/dev/null 2>&1 && break
+    sleep 1
+done
+
 # Fall back to qemu if KVM acceleration is unavailable
 if kvm-ok 2>&1 | grep -q "KVM acceleration can NOT be used"; then
     export LIBVIRT_DRIVER="qemu"
@@ -18,7 +24,20 @@ fi
 # Boot the Vagrant VM
 vagrant up --provider=libvirt
 
-# Show running domains, then keep the container alive by tailing libvirt logs
+# Show running domains
 virsh list --all
+
+# Gracefully power off the VM when the container is asked to stop (docker stop -> SIGTERM).
+# Without this the VM is hard-killed, risking a dirty shutdown / corrupt disk image.
+shutdown() {
+    echo "--> Stopping VM..."
+    vagrant halt || virsh shutdown --domain "$(virsh list --name)" || true
+    exit 0
+}
+trap shutdown SIGTERM SIGINT
+
+# Keep the container alive, surfacing libvirt logs. Run in the background (not exec)
+# so the trap above can fire on shutdown.
 touch /var/log/libvirt/libvirtd.log
-exec tail -F /var/log/libvirt/libvirtd.log
+tail -F /var/log/libvirt/libvirtd.log &
+wait $!


### PR DESCRIPTION
## Summary
- Modernize Dockerfile: `ENV K=V` syntax, merge apt + vagrant install/plugin/box into a single layer, add `--no-install-recommends`, drop apt lists at the end
- Add missing `ca-certificates`, `wget`, and `cpu-checker` (so `kvm-ok` actually works); remove unused `samba`, `rsync`, `net-tools`
- Drop the baked-in `PRIVILEGED`/`INTERACTIVE` envs (Vagrantfile defaults to true) and add OCI image labels
- Fix vagrant `.deb` install to use `apt-get install -y` instead of interactive `apt`
- startup.sh: drop leftover `pwd` and dead comments, point `libvirtd` logs at `/var/log/libvirt/libvirtd.log`, and `exec tail -F` that file so `docker logs` surfaces real activity instead of being silent