### PR TITLE
fix: restore apt recommends so vagrant-libvirt plugin builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG VAGRANT_VERSION=2.4.3
 ARG VAGRANT_BOX=peru/windows-server-2022-standard-x64-eval
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+    apt-get install -y \
         ca-certificates \
         wget \
         curl \
@@ -27,7 +27,7 @@ RUN apt-get update && \
         cpu-checker \
         build-essential && \
     wget -q "https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}-1_amd64.deb" && \
-    apt-get install -y --no-install-recommends "./vagrant_${VAGRANT_VERSION}-1_amd64.deb" && \
+    apt-get install -y "./vagrant_${VAGRANT_VERSION}-1_amd64.deb" && \
     rm -f "./vagrant_${VAGRANT_VERSION}-1_amd64.deb" && \
     vagrant plugin install vagrant-libvirt && \
     vagrant box add --provider libvirt "${VAGRANT_BOX}" && \


### PR DESCRIPTION
## Problem

The Docker build fails at `vagrant plugin install vagrant-libvirt` with:

```
Vagrant failed to install the requested plugin because it depends
on development files for a library which is not currently installed: libvirt
```

…even though `libvirt-dev` is installed.

## Root cause

This is **not** an Ubuntu version change — both builds use `ubuntu:24.04`. The cleanup in `0348df4` added `--no-install-recommends` to the apt install. That dropped `pkg-config`, which is a *Recommends* of `libvirt-dev`:

```
libvirt-dev
  Recommends: pkg-config
```

The `ruby-libvirt` native extension built by the plugin uses `pkg-config` to locate libvirt. Without it, detection fails and emits the misleading "development files … not currently installed" error.

## Fix

Remove `--no-install-recommends` to restore the previously-working build (pkg-config returns as a recommend).

Trade-off: a somewhat larger image from the extra recommended packages. The slimmer alternative would be keeping the flag and adding `pkg-config` explicitly.