### PR TITLE
ci: publish only the release version tag and latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,8 @@ jobs:
             docker.io/${{ github.repository }}
           # generate Docker tags based on the following events/attributes
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
       # - name: Set up QEMU
       #   uses: docker/setup-qemu-action@v3
       


### PR DESCRIPTION
## What

Simplify the Docker image tagging in the release workflow to publish exactly two tags per release:

- `type=semver,pattern={{version}}` → the release version (e.g. `1.0.2`)
- `type=raw,value=latest` → `latest`

## Why

The previous config also emitted `type=ref,event=branch`, `type=ref,event=pr`, and `type=semver,pattern={{major}}.{{minor}}` — producing extra tags (e.g. a `1.0` major.minor tag) that aren't wanted. Each release should map to just its version plus `latest`.

## Note

`{{version}}` requires the git tag to be valid semver (`major.minor.patch`, e.g. `1.0.2` or `v1.0.2`). A non-semver tag would be skipped and only `latest` would publish.